### PR TITLE
upd UI/UX in LoginForm

### DIFF
--- a/src/components/shared/modals/auth-modal/forms/login-form.tsx
+++ b/src/components/shared/modals/auth-modal/forms/login-form.tsx
@@ -146,7 +146,7 @@ export const LoginForm = ({ onClose }: Props) => {
 
 						<Separator className='relative my-4'>
 							<span className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-sm text-muted-foreground'>
-								or
+								or continue with
 							</span>
 						</Separator>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated copy in the Login modal: the separator between the main login action and social sign-in options now reads “or continue with” (previously “or”), clarifying provider choices. This is a purely visual copy update—no changes to behavior, validation, 2FA, or provider flows. Accessibility, keyboard navigation, and error states remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->