### PR TITLE
add truncate to AddCoin Dialog + add truncate to Filter by category

### DIFF
--- a/src/modules/coins/ui/components/add-coin.tsx
+++ b/src/modules/coins/ui/components/add-coin.tsx
@@ -149,7 +149,7 @@ export const AddCoin = () => {
 							}}
 						/>
 
-						<span className='truncate'>
+						<span className='w-60 truncate'>
 							{coin.name} ({coin.symbol.toUpperCase()})
 						</span>
 					</div>
@@ -215,7 +215,7 @@ export const AddCoin = () => {
 														e.currentTarget.src = '/svg/coin-not-found.svg'
 													}}
 												/>
-												<span>
+												<span className='truncate'>
 													{selectedCoinData.name} ({selectedCoinData.symbol.toUpperCase()})
 												</span>
 											</div>

--- a/src/modules/coins/ui/components/coin-id-container.tsx
+++ b/src/modules/coins/ui/components/coin-id-container.tsx
@@ -246,7 +246,7 @@ export const CoinIdContainer = ({ coin }: Props) => {
 					disabled={isLoading || isSaving || isAdding}
 					onClick={() => {
 						setIsNavigatingBack(true)
-						router.push('/coins')
+						router.back()
 					}}
 					className='transition-colors duration-300 ease-in-out'
 				>

--- a/src/modules/dashboard/ui/components/table-data.tsx
+++ b/src/modules/dashboard/ui/components/table-data.tsx
@@ -151,7 +151,7 @@ export function DataTable<TData, TValue>({
 
 				<div className='flex items-center gap-2'>
 					{/* Filter by category */}
-					<div className='w-full sm:w-64'>
+					<div className='w-full'>
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
 								<Button
@@ -159,7 +159,7 @@ export function DataTable<TData, TValue>({
 									variant='outline'
 									size='lg'
 									disabled={!categories.length}
-									className='group h-10 w-full justify-between rounded-xl px-4 py-2 transition-colors duration-300 ease-in-out'
+									className='group h-10 w-58 justify-between rounded-xl px-4 py-2 transition-colors duration-300 ease-in-out'
 								>
 									<span className='truncate'>{currentCategory || 'Categories'}</span>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Back button in coin details now returns to the previous page using browser history, improving navigation consistency.

* **Style**
  * Truncated long coin names in lists and selectors to prevent layout overflow.
  * Constrained coin name width in list items for better alignment.
  * Adjusted dashboard category filter layout: container now full-width and trigger uses a fixed width for more consistent spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->